### PR TITLE
Add correct release version to dist file banner

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,10 @@
   module.exports = function (grunt) {
     grunt.initConfig({
 
+      pkg: {
+        version: require('./package.json').version
+      },
+
       //////////////////////////////
       // Server
       ///////////////////////////////
@@ -115,7 +119,7 @@
             mangle: false,
             compress: false,
             beautify: true,
-            banner: "/*! eq.js 1.4.1 (c) 2014 Sam Richard, MIT license */\n"
+            banner: '/*! eq.js <%=pkg.version%> (c) 2014 Sam Richard, MIT license */\n'
           },
           files: [{
             expand: true,
@@ -129,7 +133,7 @@
           options: {
             mangle: true,
             compress: true,
-            banner: "/*! eq.js 1.4.1 (c) 2014 Sam Richard, MIT license */\n"
+            banner: '/*! eq.js <%=pkg.version%> (c) 2014 Sam Richard, MIT license */\n'
           },
           files: [{
             expand: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,7 +191,8 @@
           files: [
             'package.json',
             'bower.json'
-          ]
+          ],
+          updateConfigs: ['pkg']
           // commit: userConfig.bump.commit,
           // commitFiles: userConfig.bump.files,
           // createTag: userConfig.bump.tag,
@@ -220,5 +221,10 @@
       grunt.task.run(['uglify:distMin', 'compress:dist']);
     });
 
+    grunt.registerTask('release', 'Release a new version, push it and publish it', function (target) {
+      target = target || 'patch';
+
+      grunt.task.run('bump-only:' + target, 'build', 'bump-commit');
+    });
   };
 }());

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "deepmerge": "~0.2.5",
     "grunt": "~0.4.0",
-    "grunt-bump": "0.0.6",
+    "grunt-bump": "0.0.16",
     "grunt-contrib-compass": "~0.6.0",
     "grunt-contrib-compress": "~0.5.2",
     "grunt-contrib-connect": "~0.3.0",


### PR DESCRIPTION
Closes #26 

This adds a new grunt target `grunt release`. It has the same targets as `grunt bump`:

```
grunt release:major
grunt release:minor
grunt release:patch (default)
```

When running this task it will first update package.json and bower.json, reload the version number from pakage.json, build the dist files with the updated version in the banner and finally run the remaining part of the previous `grunt bump`.
