### PR TITLE
Workaround for libsass 3.2.x error `invalid selector after &`

### DIFF
--- a/sass/_eq.scss
+++ b/sass/_eq.scss
@@ -105,7 +105,7 @@ $EQ-Selectors: ();
   }
 
   @if not index($EQ-Selectors, &) {
-    $EQ-Selectors: append($EQ-Selectors, &, 'comma') !global;
+    $EQ-Selectors: append($EQ-Selectors, #{&}, 'comma') !global;
   }
 }
 


### PR DESCRIPTION
Fix for #45 - workaround for libsass 3.2.x bug throwing `invalid selector after &` error
