### PR TITLE
Allow events to bubble

### DIFF
--- a/build/eq.js
+++ b/build/eq.js
@@ -190,7 +190,7 @@
         obj.setAttribute('data-eq-state', eqState);
       }
       // Set the details of `eqResize`
-      eqResizeEvent = new CustomEvent('eqResize', {'detail': eqState});
+      eqResizeEvent = new CustomEvent('eqResize', {'detail': eqState, 'bubbles': true});
 
       // Fire resize event
       obj.dispatchEvent(eqResizeEvent);

--- a/tests/attribute.js
+++ b/tests/attribute.js
@@ -117,4 +117,14 @@ describe('Set the `data-eq-state` attribute based on element width and its `data
       expect(eventSpy).toHaveBeenCalled();
     });
   });
+
+  it('should allow events to bubble up through the DOM', function() {
+    var eventSpy = jasmine.createSpy();
+    body.style.width = (sizes[0]) + 'px';
+    body.addEventListener('eqResize', eventSpy);
+    eqjs.refreshNodes();
+    eqjs.query(undefined, function () {
+      expect(eventSpy).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
If an element higher up in the DOM needs to know when something inside changes due to an element query, we want to be able to listen for any `eqResize` events inside it.

Resolves #52.
